### PR TITLE
Update README.md (remove lua 5.3 dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@
 ## Prerequisites
 
 - [NeoVim nightly](https://github.com/neovim/neovim/releases/tag/nightly) (>=v0.5.0)
-- [Lua ver. >= 5.3](https://www.lua.org/manual/5.3/readme.html#changes)
 
 ## Adding the plugin
 You can use your favorite plugin manager for this. Here are some examples with the most popular ones:


### PR DESCRIPTION
As discussed, goto was then feature warranting lua 5.3 dependency. Since it' also available under lua 5.2 (https://www.lua.org/versions.html#5.2) and most importantly under lua JIT (https://luajit.org/extensions.html), which is the only version officially supported by neovim anyways, I would simply remove that dependency.