### PR TITLE
Fix Feline Statusline

### DIFF
--- a/lua/true-zen/services/integrations/feline.lua
+++ b/lua/true-zen/services/integrations/feline.lua
@@ -4,7 +4,7 @@ local api = vim.api
 local M = {}
 
 function M.enable_element()
-	vim.o.statusline = '%!v:lua.require\'feline\'.statusline()'
+	vim.o.statusline = '%{%v:lua.require\'feline\'.generate_statusline()%}'
 	-- stylua: ignore
 	api.nvim_exec([[
 		aug feline


### PR DESCRIPTION
Feline updated their statusline value to `"%{%v:lua.require'feline'.generate_statusline()%}"` in the [winbar](https://github.com/feline-nvim/feline.nvim/pull/267) support. This commit only fix statusline value. The winbar option isn't tested.