### PR TITLE
fix: `'listchars'` visible in padding windows

### DIFF
--- a/lua/true-zen/services/modes/mode-ataraxis/service.lua
+++ b/lua/true-zen/services/modes/mode-ataraxis/service.lua
@@ -234,7 +234,7 @@ local function gen_window_specs(gen_command, command, extra)
 		cmd(command)
 		cmd(
 			[[
-			setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile nocursorline nocursorcolumn nonumber norelativenumber noruler noshowmode noshowcmd laststatus=0 ]]
+			setlocal buftype=nofile bufhidden=wipe nomodifiable nobuflisted noswapfile nocursorline nocursorcolumn nonumber norelativenumber noruler nolist noshowmode noshowcmd laststatus=0 ]]
 				.. get_winhl()
 				.. [[ | let w:truezen_window = 'true']]
 		)


### PR DESCRIPTION
If the user set `eol` in `listchars` and `list` to `true`, the character they chose for `eol` would show in the padding windows for Ataraxis mode.

## Before:
![bad](https://user-images.githubusercontent.com/38332081/176830104-b973a7b6-ab68-45f0-b72f-01f66254ff1e.png)

## After:
![good](https://user-images.githubusercontent.com/38332081/176830122-edfeeef2-de34-4429-807b-d358edbdb61c.png)

(I have `vim.wo.list = false` in `after_mode_ataraxis_on`, which is why the main windows in my screenshots don't show `listchars`)