### PR TITLE
fix: lualine restoration

### DIFF
--- a/lua/true-zen/services/integrations/lualine.lua
+++ b/lua/true-zen/services/integrations/lualine.lua
@@ -5,7 +5,7 @@ local M = {}
 function M.enable_element()
 	vim.g.ran = true
 	-- cmd([[set statusline=%!v:lua.require'lualine'.statusline()]])
-	vim.o.statusline = "%!v:lua.require'lualine'.statusline()"
+	vim.o.statusline = "%{%v:lua.require'lualine'.statusline()%}"
 	-- stylua: ignore
 	vim.api.nvim_exec([[
 		augroup lualine


### PR DESCRIPTION
# Problem

Before activating Zen Ataraxis, the value of `'statusline'` is as follows:

```vim
%{%v:lua.require'lualine'.statusline()%}
```

After activating and deactivating it, here's the new value of `'statusline'`:

```vim
%!v:lua.require'lualine'.statusline()
```

Here's the relevant `:help` documentation for reference (see `:h 'statusline'` for full info):

```
	When the option starts with "%!" then it is used as an expression,
	evaluated and the result is used as the option value.  Example:
		:set statusline=%!MyStatusLine()
	The *g:statusline_winid* variable will be set to the |window-ID| of the
	window that the status line belongs to.
	The result can contain %{} items that will be evaluated too.
	Note that the "%!" expression is evaluated in the context of the
	current window and buffer, while %{} items are evaluated in the
	context of the window that the statusline belongs to.

...

	{ NF  Evaluate expression between '%{' and '}' and substitute result.
	      Note that there is no '%' before the closing '}'.  The
	      expression cannot contain a '}' character, call a function to
	      work around that.  See |stl-%{| below.
	{% -  This is almost same as { except the result of the expression is
	      re-evaluated as a statusline format string.  Thus if the
	      return value of expr contains % items they will get expanded.
	      The expression can contain the } character, the end of
	      expression is denoted by %}.
	      For example:
		func! Stl_filename() abort
		    return "%t"
		endfunc
	        `stl=%{Stl_filename()}`   results in `"%t"`
	        `stl=%{%Stl_filename()%}` results in `"Name of current file"`
	%} -  End of `{%` expression
```

## Expected:
![Screen Shot 2022-07-01 at 2 23 16 AM](https://user-images.githubusercontent.com/38332081/176845308-19e00a42-912f-42b3-b3c5-54c9dfc3cb2a.png)

## Actual:
![Screen Shot 2022-07-01 at 2 23 53 AM](https://user-images.githubusercontent.com/38332081/176845390-4c4a08f7-a0ed-469d-af26-336728339de3.png)