### PR TITLE
Add alacritty integration to change font size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ https://user-images.githubusercontent.com/58336662/181860318-8834446a-e28f-4a75-
 -   integratons:
     -   [tmux](https://github.com/tmux/tmux)
     -   [kitty](https://sw.kovidgoyal.net/kitty/)
+    -   [alacritty](https://alacritty.org/)
     -   [twilight.nvim](https://github.com/folke/twilight.nvim)
 	- [nvim-lualine](https://github.com/nvim-lualine/lualine.nvim)
 
@@ -160,6 +161,10 @@ true-zen comes with the following defaults:
 		kitty = { -- increment font size in Kitty. Note: you must set `allow_remote_control socket-only` and `listen_on unix:/tmp/kitty` in your personal config (ataraxis)
 			enabled = false,
 			font = "+3"
+		},
+		alacritty = { -- increment font size in Alacrity. Requires v 0.10.0 or higher. Uses `alacritty msg` subcommand to toggle font size
+			enabled = false,
+			font = "24"
 		},
 		twilight = false, -- enable twilight (ataraxis)
 		lualine = false -- hide nvim-lualine (ataraxis)

--- a/lua/true-zen/config.lua
+++ b/lua/true-zen/config.lua
@@ -74,6 +74,10 @@ config.options = {
 			enabled = false,
 			font = "+3"
 		},
+		alacritty = {
+			enabled = false,
+			font = "24"
+		},
 		twilight = false, -- enable twilight (ataraxis)
 		lualine = false -- hide nvim-lualine (ataraxis)
 	},

--- a/lua/true-zen/integrations/alacritty.lua
+++ b/lua/true-zen/integrations/alacritty.lua
@@ -1,0 +1,27 @@
+local M = {}
+
+local cnf = require("true-zen.config").options
+local fn = vim.fn
+local status
+
+function M.on()
+    if not fn.executable("alacritty") then
+        return
+    end
+    local cmd = "alacritty msg config -w %s font.size=%s"
+    local win_id = fn.expand("$ALACRITTY_WINDOW_ID")
+    fn.system(cmd:format(win_id, cnf.integrations.alacritty.font))
+    vim.cmd([[redraw]])
+    status = true
+end
+
+function M.off()
+    if status == true then
+        local cmd = "alacritty msg config -w %s --reset"
+        local win_id = fn.expand("$ALACRITTY_WINDOW_ID")
+        fn.system(cmd:format(win_id))
+    end
+    status = nil
+end
+
+return M


### PR DESCRIPTION
Similar to kitty, adds an integration for Alacritty to change the font size. Uses Alacritty's `msg` subcommand 

![](https://snid.es/2023AUG/IgttZBtbDPUP0FM6.gif)